### PR TITLE
[Impove]改进关于mysql jdbc版本的问题

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/user-guide/1-deployment.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/user-guide/1-deployment.md
@@ -228,14 +228,14 @@ spring:
  
 在修改完 `conf/application.yml` 后, 还需要修改 `config/application-mysql.yml` 中的数据库连接信息:
 
-**Tips: 由于Apache 2.0许可与Mysql Jdbc驱动许可的不兼容，用户需要自行下载驱动jar包并放在 $STREAMPARK_HOME/lib 中**
+**Tips: 由于Apache 2.0许可与Mysql Jdbc驱动许可的不兼容，用户需要自行下载驱动jar包并放在 $STREAMPARK_HOME/lib 中,推荐使用8.x版本,下载地址[apache maven repository](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/)**
 
 ```yaml
 spring:
   datasource:
     username: root
     password: xxxx
-    driver-class-name: com.mysql.cj.jdbc.Driver   # 如果你使用的是 mysql-5.x，则此处的驱动名称应该是：com.mysql.jdbc.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver   # 请根据mysql-connector-java版本确定具体的路径,例如:使用5.x则此处的驱动名称应该是：com.mysql.jdbc.Driver
     url: jdbc:mysql://localhost:3306/streampark?useSSL=false&useUnicode=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=false&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=GMT%2B8
 ```
 


### PR DESCRIPTION
原因:
在使用mysql-connector-java-5.1.1.jar(mysql的版本是:5.7.39)的时候,登陆界面会报错(附在最后),看起来是mybatisplus的兼容性问题导致的,解决方案是使用8.x的jar包.

报错信息:
Caused by: java.lang.AbstractMethodError: Method com/mysql/jdbc/JDBC4ResultSet.getObject(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object; is abstract
	at com.mysql.jdbc.JDBC4ResultSet.getObject(JDBC4ResultSet.java)
	at com.zaxxer.hikari.pool.HikariProxyResultSet.getObject(HikariProxyResultSet.java)
	at com.baomidou.mybatisplus.core.handlers.MybatisEnumTypeHandler.getNullableResult(MybatisEnumTypeHandler.java:118)
	at com.baomidou.mybatisplus.core.handlers.MybatisEnumTypeHandler.getNullableResult(MybatisEnumTypeHandler.java:49)
	at org.apache.ibatis.type.BaseTypeHandler.getResult(BaseTypeHandler.java:85)
	at com.baomidou.mybatisplus.core.handlers.CompositeEnumTypeHandler.getResult(CompositeEnumTypeHandler.java:62)
	at com.baomidou.mybatisplus.core.handlers.CompositeEnumTypeHandler.getResult(CompositeEnumTypeHandler.java:37)
	at org.apache.ibatis.executor.resultset.DefaultResultSetHandler.applyAutomaticMappings(DefaultResultSetHandler.java:572)
	at org.apache.ibatis.executor.resultset.DefaultResultSetHandler.getRowValue(DefaultResultSetHandler.java:409)
	at org.apache.ibatis.executor.resultset.DefaultResultSetHandler.handleRowValuesForSimpleResultMap(DefaultResultSetHandler.java:361)
	at org.apache.ibatis.executor.resultset.DefaultResultSetHandler.handleRowValues(DefaultResultSetHandler.java:335)
	at org.apache.ibatis.executor.resultset.DefaultResultSetHandler.handleResultSet(DefaultResultSetHandler.java:308)
	at org.apache.ibatis.executor.resultset.DefaultResultSetHandler.handleResultSets(DefaultResultSetHandler.java:201)
	at org.apache.ibatis.executor.statement.PreparedStatementHandler.query(PreparedStatementHandler.java:65)
	at org.apache.ibatis.executor.statement.RoutingStatementHandler.query(RoutingStatementHandler.java:79)