### PR TITLE
[docs][typo]Fix main class name typo error

### DIFF
--- a/docs/user-guide/3-development.md
+++ b/docs/user-guide/3-development.md
@@ -141,7 +141,7 @@ java:
 
 #### Backend startup
 
-`StreamPark console` is a web application developed based on springboot, `org.apache.streampark.console.StreamParkConsole` is the main class. Before startup, you need to set `VM options` and `environment variables`
+`StreamPark console` is a web application developed based on springboot, `org.apache.streampark.console.StreamParkConsoleBootstrap` is the main class. Before startup, you need to set `VM options` and `environment variables`
 
 ##### VM options
 
@@ -163,7 +163,7 @@ If you use a non locally installed Hadoop cluster (test Hadoop), you need to con
 
 <img src="/doc/image/streampark_ideaopt.jpg" />
 
-If everything is ready, you can start the `StreamParkConsole` main class. If it is started successfully, you will see the printing information of successful startup.
+If everything is ready, you can start the `StreamParkConsoleBootstrap` main class. If it is started successfully, you will see the printing information of successful startup.
 
 ### Frontend deployment and configuration
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/user-guide/3-development.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/user-guide/3-development.md
@@ -140,7 +140,7 @@ java:
 
 #### 启动
 
-`streampark-console` 是基于 springBoot 开发的 web 应用，`org.apache.streampark.console.StreamParkConsole` 为主类， 在启动主类之前，需要设置下 `VM options` 和 `Environment variables`
+`streampark-console` 是基于 springBoot 开发的 web 应用，`org.apache.streampark.console.StreamParkConsoleBootstrap` 为主类， 在启动主类之前，需要设置下 `VM options` 和 `Environment variables`
 
 ##### VM options
 
@@ -162,7 +162,7 @@ java:
 
 <img src="/doc/image/streampark_ideaopt.jpg" />
 
-如果一切准假就绪，就可以用 `StreamParkConsole` 主类启动项目，如果启动成功，就会看到有启动成功的信息输出
+如果一切准假就绪，就可以用 `StreamParkConsoleBootstrap` 主类启动项目，如果启动成功，就会看到有启动成功的信息输出
 
 ### 前端
 


### PR DESCRIPTION
Fixed main class  typo error ,The name shoud be StreamParkConsoleBootstrap.