### PR TITLE
[Improve] Improve flying book alarm docs

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/alert-conf.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/alert-conf.md
@@ -94,9 +94,10 @@ import TabItem from '@theme/TabItem';
 
 **配置项说明：**
 
-1.   `Lark Token`：<font color='red'>`必填项`</font>。为群机器人默认地址，截取 `/hook/` 后面内容。
-2.   `At All User`：选填项 。开启后，报警消息会@群内所有人。
-3.   `Secret Enable`：选填项 。如果开启机器人请求 `加密验签`，则需要配置，并且需要配置 `Lark Secret Token` 验签密钥信息。
+1.    `streampark.proxy.lark-url`：添加 `streampark.proxy.lark-url` 属性到配置文件中。 例子: 在yaml文件中加入 streampark.proxy.lark-url: https://open.feishu.cn 。
+2.    `Lark Token`：<font color='red'>`必填项`</font>。为群机器人默认地址，截取 `/hook/` 后面内容。
+3.   `At All User`：选填项 。开启后，报警消息会@群内所有人。
+4.   `Secret Enable`：选填项 。如果开启机器人请求 `加密验签`，则需要配置，并且需要配置 `Lark Secret Token` 验签密钥信息。
 
 :::info 飞书群机器人申请
 请参考 `飞书官方文档` https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/bot-v3/bot-overview 进行机器人申请和配置


### PR DESCRIPTION

When setting the flying book alarm, an error was reported, indicating that the url was incorrect,As shown in the figure：
<img width="737" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/69e44842-0806-4ce3-8766-18c61de1d0ec">

We run the local environment, debug the code, and find that the larkProxyUrl variable is getting a null value. Null values are resolved by setting the property streampark.proxy.lark-url
<img width="526" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/57743042-03a3-4a53-b946-1a4dd39fc819">

Go to our yaml file and add streampark.proxy.lark-url to compile and debug the flybook alarm again. Messages can be sent normally.
<img width="409" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/d668903f-381c-448f-a427-de216db89fc9">
<img width="555" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/89c4f24a-3605-4343-8757-7f1ee060cd95">

Alarm information from the flying book Group test

<img width="749" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/c5a43c57-0b07-438e-9e62-db93b77ef049">

@caicancai