### PR TITLE
[Improve] Improve  lark alarm docs 

### DIFF
--- a/docs/development/alert-conf.md
+++ b/docs/development/alert-conf.md
@@ -104,9 +104,10 @@ Then, Enter robot `Lark Tokens` and other configurations, click `Submit`.
 
 **Configuration description：**
 
-1. `Lark Token`：<font color='red'>`Required`</font>.1. It is the default address of the group robot, intercept the content behind `/hook/`.
-2. `At All User`：`optional` .2.After it is turned on, the alarm message will be @ everyone in the group.
-3. `Secret Enable`：`optional` .3.If `encryption signature verification` is enabled, the `Secret Token` signature verification key information needs to be configured.
+1. `streampark.proxy.lark-url`：We need to add the `streampark.proxy.lark-url` property to the configuration file. Example: yaml file adds streampark.proxy.lark-url: https://open.feishu.cn .
+2. `Lark Token`：<font color='red'>`Required`</font>.1. It is the default address of the group robot, intercept the content behind `/hook/`.
+3. `At All User`：`optional` .2.After it is turned on, the alarm message will be @ everyone in the group.
+4. `Secret Enable`：`optional` .3.If `encryption signature verification` is enabled, the `Secret Token` signature verification key information needs to be configured.
 
 :::info Lark robot application
 Please refer to the [official Lark official](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/bot-v3/bot-overview ) for robot application and configuration

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/alert-conf.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/alert-conf.md
@@ -94,9 +94,10 @@ import TabItem from '@theme/TabItem';
 
 **配置项说明：**
 
-1.   `Lark Token`：<font color='red'>`必填项`</font>。为群机器人默认地址，截取 `/hook/` 后面内容。
-2.   `At All User`：选填项 。开启后，报警消息会@群内所有人。
-3.   `Secret Enable`：选填项 。如果开启机器人请求 `加密验签`，则需要配置，并且需要配置 `Lark Secret Token` 验签密钥信息。
+1. `streampark.proxy.lark-url`：添加 `streampark.proxy.lark-url`属性到配置文件中，例：在yaml文件中添加 streampark.proxy.lark-url: https://open.feishu.cn 。  
+2. `Lark Token`：<font color='red'>`必填项`</font>。为群机器人默认地址，截取 `/hook/` 后面内容。
+3. `At All User`：选填项 。开启后，报警消息会@群内所有人。
+4. `Secret Enable`：选填项 。如果开启机器人请求 `加密验签`，则需要配置，并且需要配置 `Lark Secret Token` 验签密钥信息。
 
 :::info 飞书群机器人申请
 请参考 `飞书官方文档` https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/bot-v3/bot-overview 进行机器人申请和配置


### PR DESCRIPTION
When setting the flying book alarm, an error was reported, indicating that the url was incorrect,As shown in the figure：
<img width="734" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/ee58c97e-fd8d-45a4-bb75-5d371b83896d">

We run the local environment, debug the code, and find that the larkProxyUrl variable is getting a null value. Null values are resolved by setting the property streampark.proxy.lark-url
<img width="525" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/fa7750ff-1f0a-4287-8e9d-9edb20a28d76">

Go to our yaml file and add streampark.proxy.lark-url to compile and debug the flybook alarm again. Messages can be sent normally.
<img width="397" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/c9c70287-b86c-4b5e-badf-bdd27a7e306f">
<img width="544" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/3d359d76-5b52-4a73-a9a3-3241f398aed3">

Alarm information from the flying book Group test

<img width="530" alt="image" src="https://github.com/apache/incubator-streampark-website/assets/18672845/001e95aa-8b74-4677-adf5-7dbcafe9b057">
@caicancai