### PR TITLE
[Improve] add Use `isEmpty()` instead of `length() == 0` or `size() == 0` rule

### DIFF
--- a/community/submit_guide/code-style-and-quality-guide.md
+++ b/community/submit_guide/code-style-and-quality-guide.md
@@ -249,6 +249,24 @@ sidebar_position: 3
     public CurrentHashMap funName();
   ```
 
+3. Use `isEmpty()` instead of `length() == 0` or `size() == 0`
+
+    - Negative demo：
+
+       ```java
+       if (pathPart.length() == 0) {
+         return;
+       }
+       ```
+
+    - Positive demo：
+
+      ```java
+      if (pathPart.isEmpty()) {
+        return;
+      }
+      ```
+
 ### 3.5 Concurrent Processing
 
 1. The `thread pool` needs to be managed, using a unified entry point to obtain the `thread pool`.

--- a/community/submit_guide/code-style-and-quality-guide.md
+++ b/community/submit_guide/code-style-and-quality-guide.md
@@ -253,11 +253,11 @@ sidebar_position: 3
 
     - Negative demo：
 
-       ```java
-       if (pathPart.length() == 0) {
-         return;
-       }
-       ```
+      ```java
+      if (pathPart.length() == 0) {
+        return;
+      }
+      ```
 
     - Positive demo：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/submit_guide/code-style-and-quality-guide.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/submit_guide/code-style-and-quality-guide.md
@@ -249,6 +249,24 @@ sidebar_position: 3
     public CurrentHashMap funName();
   ```
 
+3. 使用 `isEmpty()` 而不是 `length() == 0` 或者 `size() == 0`
+
+   - 负面示例：
+
+      ```java
+      if (pathPart.length() == 0) {
+        return;
+      }
+      ```
+
+   - 正面示例：
+
+     ```java
+     if (pathPart.isEmpty()) {
+       return;
+     }
+     ```
+
 ### 3.5 并发处理
 
 1. 需要管理 `线程池`，使用统一的入口点获取 `线程池`。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/submit_guide/code-style-and-quality-guide.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/submit_guide/code-style-and-quality-guide.md
@@ -253,11 +253,11 @@ sidebar_position: 3
 
    - 负面示例：
 
-      ```java
-      if (pathPart.length() == 0) {
-        return;
-      }
-      ```
+     ```java
+     if (pathPart.length() == 0) {
+       return;
+     }
+     ```
 
    - 正面示例：
 


### PR DESCRIPTION
This PR introduces an improvement to our coding practices by advocating the use of the `isEmpty()` method over the `length() == 0` or `size() == 0` for collections checks in Java.

This rule encourages developers to adopt a more semantic and cleaner way of checking for collections. It's a small but meaningful step towards improving the overall quality of our codebase.