### PR TITLE
fix(hero): Fix 404 jump when clicking Get started

### DIFF
--- a/src/pages/home/hero.jsx
+++ b/src/pages/home/hero.jsx
@@ -52,7 +52,7 @@ export default function () {
                    target="_blank">
                   <i className="lni-github-original"></i>&nbsp;GitHub
                 </a>
-                <a className="btn streampark-btn btn-green mt-30 ml-3 ztop" href="/docs/user-guide/quick-start"
+                <a className="btn streampark-btn btn-green mt-30 ml-3 ztop" href="/docs/get-started/intro"
                    style={{marginLeft: '10px'}}>
                   <i className="lni-play"></i>&nbsp;Get started
                 </a>


### PR DESCRIPTION
#397

I fixed the bug where clicking on Get started jumped to a 404
I don't know if this jump address is what you'd expect or not!

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/1f386381-8573-4658-a93b-38bdfd2a2872">
