### PR TITLE
docs: 2.1.4 release note

### DIFF
--- a/src/pages/download/release-note/2.1.5.md
+++ b/src/pages/download/release-note/2.1.5.md
@@ -3,27 +3,24 @@
 
 <div style={{height: '30px'}}></div>
 
-Apache StreamPark (incubating) 2.1.5 introduces several new features, important improvements, and bug fixes, including support for Flink 1.20. This release significantly enhances the stability and user experience of the platform. Users are strongly recommended to upgrade.
+Apache StreamPark (incubating) 2.1.5 introduces new features, important improvements, and bug fixes, including support for Flink 1.20. This release significantly enhances the stability and user experience of the platform. Users are recommended to upgrade.
 
 <div style={{height: '30px'}}></div>
 
 ### Features
 ---
 - Support for Apache Flink 1.20 #3994
-- Added one-click installation script for StreamPark #3748
-- Introduced Flink Web UI proxy support #3931
+- Added StreamPark one-click installation script #3748
+- The Flink Web UI proxy support #3931
 - Git clone by Git tag support #4009
-- Changed Rest-Service Exposed Type from LoadBalancer to ClusterIP #4019
 
 ### Bugfix
 ---
-- Fixed Kubernetes application mode savepoint trigger bug #3995
-- Fixed OpenAPI access issue #3938
+- Flink job on Kubernetes-application-mode trigger savepoint bug Fixed  #3995
 - Fixed Flink VVR version parsing issue #3866
 - Fixed DingTalk alert issue #3730
 - Fixed Kerberos authentication issues in Flink on YARN #3951
 - Resolved issue where HA files were not cleaned after Flink job completion, leading to duplicate job starts #4029
-- Fixed state update failure issue #4030
 - Fixed issue with loading flink-conf #4109
 
 ### Improvements
@@ -37,13 +34,9 @@ Apache StreamPark (incubating) 2.1.5 introduces several new features, important 
 - Minor improvements to Flink checkpoint configuration keys #4004
 - Multi-version adaptation support for Flink on YARN #4007
 - JVM options optimization #4010
-- Improved user experience for Flink Web UI proxy #4012
-- Changed project page layout to table format #4014
-- Custom-code jobs now support reading configurations from JAR files #4055
+- Custom-code jobs now support get configurations from JAR files #4055
 - Added jobId labels to pods deployed in Kubernetes mode #4063
 - Added support for variables in Flink configurations #4065
-- Improved project modal and Flink cluster modal #4067
-- Improved table actions style on the project display page #4084
 
 ### New Contributors
 ---

--- a/src/pages/download/release-note/2.1.5.md
+++ b/src/pages/download/release-note/2.1.5.md
@@ -1,0 +1,54 @@
+
+## Release Notes 2.1.5
+
+<div style={{height: '30px'}}></div>
+
+Apache StreamPark (incubating) 2.1.5 introduces several new features, important improvements, and bug fixes, including support for Flink 1.20. This release significantly enhances the stability and user experience of the platform. Users are strongly recommended to upgrade.
+
+<div style={{height: '30px'}}></div>
+
+### Features
+---
+- Support for Apache Flink 1.20 #3994
+- Added one-click installation script for StreamPark #3748
+- Introduced Flink Web UI proxy support #3931
+- Git clone by Git tag support #4009
+- Changed Rest-Service Exposed Type from LoadBalancer to ClusterIP #4019
+
+### Bugfix
+---
+- Fixed Kubernetes application mode savepoint trigger bug #3995
+- Fixed OpenAPI access issue #3938
+- Fixed Flink VVR version parsing issue #3866
+- Fixed DingTalk alert issue #3730
+- Fixed Kerberos authentication issues in Flink on YARN #3951
+- Resolved issue where HA files were not cleaned after Flink job completion, leading to duplicate job starts #4029
+- Fixed state update failure issue #4030
+- Fixed issue with loading flink-conf #4109
+
+### Improvements
+---
+- Optimized log printing and return handling in GlobalExceptionHandler #3705
+- Disabled the TRACE HTTP method for security enhancement #3718
+- Enhanced logging with more debug information #3720
+- Improved Docker settings for better deployment #3864
+- Removed Swagger dependencies #3893
+- Enhanced proxy permission checks and fixed URL bug for YARN #3986
+- Minor improvements to Flink checkpoint configuration keys #4004
+- Multi-version adaptation support for Flink on YARN #4007
+- JVM options optimization #4010
+- Improved user experience for Flink Web UI proxy #4012
+- Changed project page layout to table format #4014
+- Custom-code jobs now support reading configurations from JAR files #4055
+- Added jobId labels to pods deployed in Kubernetes mode #4063
+- Added support for variables in Flink configurations #4065
+- Improved project modal and Flink cluster modal #4067
+- Improved table actions style on the project display page #4084
+
+### New Contributors
+---
+- @soulmz made their first contribution in #3717
+- @lintingbin made their first contribution in #3931
+- @lizh501 made their first contribution in #4007
+
+**Full Changelog**: https://github.com/apache/incubator-streampark/compare/v2.1.4...v2.1.5


### PR DESCRIPTION

## Release Notes 2.1.5

<div style={{height: '30px'}}></div>

Apache StreamPark (incubating) 2.1.5 introduces several new features, important improvements, and bug fixes, including support for Flink 1.20. This release significantly enhances the stability and user experience of the platform. Users are strongly recommended to upgrade.

<div style={{height: '30px'}}></div>

### Features
---
- Support for Apache Flink 1.20 #3994
- Added one-click installation script for StreamPark #3748
- Introduced Flink Web UI proxy support #3931
- Git clone by Git tag support #4009
- Changed Rest-Service Exposed Type from LoadBalancer to ClusterIP #4019

### Bugfix
---
- Fixed Kubernetes application mode savepoint trigger bug #3995
- Fixed OpenAPI access issue #3938
- Fixed Flink VVR version parsing issue #3866
- Fixed DingTalk alert issue #3730
- Fixed Kerberos authentication issues in Flink on YARN #3951
- Resolved issue where HA files were not cleaned after Flink job completion, leading to duplicate job starts #4029
- Fixed state update failure issue #4030
- Fixed issue with loading flink-conf #4109

### Improvements
---
- Optimized log printing and return handling in GlobalExceptionHandler #3705
- Disabled the TRACE HTTP method for security enhancement #3718
- Enhanced logging with more debug information #3720
- Improved Docker settings for better deployment #3864
- Removed Swagger dependencies #3893
- Enhanced proxy permission checks and fixed URL bug for YARN #3986
- Minor improvements to Flink checkpoint configuration keys #4004
- Multi-version adaptation support for Flink on YARN #4007
- JVM options optimization #4010
- Improved user experience for Flink Web UI proxy #4012
- Changed project page layout to table format #4014
- Custom-code jobs now support reading configurations from JAR files #4055
- Added jobId labels to pods deployed in Kubernetes mode #4063
- Added support for variables in Flink configurations #4065
- Improved project modal and Flink cluster modal #4067
- Improved table actions style on the project display page #4084

### New Contributors
---
- @soulmz made their first contribution in #3717
- @lintingbin made their first contribution in #3931
- @lizh501 made their first contribution in #4007

**Full Changelog**: https://github.com/apache/incubator-streampark/compare/v2.1.4...v2.1.5
