### PR TITLE
[Improve] link project-specific security page in menu

### DIFF
--- a/community/security.md
+++ b/community/security.md
@@ -23,4 +23,4 @@ Please specify the project name as "StreamPark" in the email, and provide a desc
 
 The Apache Security Team and the StreamPark community will get back to you after assessing and analyzing the findings.
 
-Please note that the security issue should be reported on the security email first, before disclosing it on any public domain.
+Please note that the security issue should be reported on the security email first, before disclosing it on any public domain. For more information see https://apache.org/security

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -160,7 +160,7 @@ const config = {
               },
               {
                 label: "Security",
-                to: "https://www.apache.org/security/",
+                to: "/community/security/",
               },
               {
                 label: "Sponsorship",


### PR DESCRIPTION
This makes the project-specific information more prominent, so that people will first see the project-specific information before perhaps continuing to the generic information on https://apache.org/security/