### PR TITLE
[Fix] navbar sidebar height issue on mobile

### DIFF
--- a/src/css/custom/index.less
+++ b/src/css/custom/index.less
@@ -964,8 +964,8 @@ body {
   backdrop-filter: blur(12px);
 
   .navbar-sidebar {
-    background: inherit;
     z-index: 11;
+    height: 100vh;
   }
 
   // 切换主题，防止抖动


### PR DESCRIPTION
## Problem
- On mobile view, the navbar sidebar does not occupy the full viewport height.

## What changes were made
- Updated the height to `100vh` so that sidebar take full viewport height.

## Screenshots
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td width="50%">
      <video src="https://github.com/user-attachments/assets/dc31c590-8dc4-44ad-acec-128f3fbcf4b6" controls></video>
    </td>
    <td width="50%">
      <video src="https://github.com/user-attachments/assets/96f43dac-9cad-40ec-a9e3-76037c83e86d" controls></video>
    </td>
  </tr>
</table>